### PR TITLE
Fix typo in the instructions

### DIFF
--- a/plugin/unicycle.vim
+++ b/plugin/unicycle.vim
@@ -8,7 +8,7 @@
 " works if set encoding=utf-8.
 "
 " To install, drop it in your plugins directory. To use, execute the
-" :UniCycleOn command. Turn turn it off, execute :UniCycleOff.
+" :UniCycleOn command. To turn it off, execute :UniCycleOff.
 "
 " When on, the hyphen (-), period (.), apostrophe ('), and quote (")
 " characters are mapped to the appropriate functions within this file.


### PR DESCRIPTION
Fix for minor typo in the instructions

_Edit: I thought this was Jason's own github mirror as this repo was the at the top of Google's search results._
